### PR TITLE
Markdown-Formatierung FAQ 1.

### DIFF
--- a/docs/FAQ/FAQ.qmd
+++ b/docs/FAQ/FAQ.qmd
@@ -4,15 +4,26 @@ title: "FAQ"
 
 ## 1. Wie poole ich mein $R^2$ richtig über mehrere (bspw. 15) Imputationen?
 
-### a. Die von Harel (2009) vorgeschlagene Methode beinhaltet mehrere Schritte:
+### a. Methode nach Harel (2009)
 
-Die Quadratwurzel aus $R^2$ ziehen; eine Fisher *z*-Transformation durchführen, damit der Wertebereich auf alle reellen Zahlen ausgeweitet wird; Rubins Regeln für metrische Variablen anwenden; mit einer inversen *z*-Transformation den Wert wieder zurückrechnen und quadrieren
-
-### b. Im Paket eatRep kann das über die Funktion pool.R2() berechnet werden.
-
-Die Funktion wird momentan noch nicht auf den Namensraum (Namespace) des Pakets exportiert, was allerdings ab der nächsten Paketversion möglich sein wird. Angenommen, aus einer Analyse multipel imputierter Daten resultieren 5 verschiedene (hier fiktive) $R^2$-Werte, dann kann der gepoolte $R^2$-Wert folgendermaßen bestimmt werden: r2 \<- c(0.12,0.18,0.17,0.21,0.23); eatRep:::pool.R2(r2)
+Die von Harel (2009) vorgeschlagene Methode beinhaltet mehrere Schritte:  
+1. Die Quadratwurzel aus $R^2$ ziehen  
+2. eine Fisher *z*-Transformation durchführen, damit der Wertebereich auf alle reellen Zahlen ausgeweitet wird  
+3. Rubins Regeln für metrische Variablen anwenden  
+4. mit einer inversen *z*-Transformation den Wert wieder zurückrechnen und quadrieren
 
 Harel, O. (2009). The estimation of R2 and adjusted R2 in incomplete data sets using multiple imputation. *Journal of Applied Statistics, 36*(10), 1109-1118.
+
+### b. pool.R2() aus eatRep
+
+Im Paket eatRep kann das über die Funktion `pool.R2()` berechnet werden. Die Funktion wird momentan noch nicht auf den Namensraum (Namespace) des Pakets exportiert, was allerdings ab der nächsten Paketversion möglich sein wird.
+
+Angenommen, aus einer Analyse multipel imputierter Daten resultieren 5 verschiedene (hier fiktive) $R^2$-Werte, dann kann der gepoolte $R^2$-Wert folgendermaßen bestimmt werden:
+
+```{r eval = FALSE}
+r2 <- c(0.12,0.18,0.17,0.21,0.23)
+eatRep::pool.R2(r2)
+```
 
 ## 2. DIF-Richtung in Conquest/eatModel: Was bedeuten negative Werte in der "estDif"-Spalte?
 


### PR DESCRIPTION
Ich würde 1a) als Liste formatieren und "r2 <- c(0.12,0.18,0.17,0.21,0.23); eatRep::pool.R2(r2)" als Code-Chunk darstellen.